### PR TITLE
IPCs can be fully built in the mech fabricator

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -2,7 +2,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 
 /obj/item/mmi/posibrain
 	name = "positronic brain"
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves.<br>Can be transformed into an IPC brain with <b>Ctrl+Click</b>!"
 	icon = 'icons/obj/assemblies/assemblies.dmi'
 	icon_state = "posibrain"
 	base_icon_state = "posibrain"
@@ -85,6 +85,32 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	to_chat(user, span_notice("You set the personality seed to \"[input_seed]\"."))
 	ask_role = input_seed
 	update_appearance()
+
+/obj/item/mmi/posibrain/CtrlClick(mob/user)
+	if(!brainmob?.mind || !brainmob)
+		to_chat(user, span_notice("You press the button and release it, but nothing happens because the positronic brain is inactive."))
+		return
+	else if(brainmob.ckey == user.ckey)
+		to_chat(brainmob, span_notice("You cannot press your button itself, so nothing happens."))
+		return
+	to_ipc_posi(user)
+	to_chat(user, span_notice("You press the button to transform the positronic brain into an IPC brain."))
+
+/obj/item/mmi/posibrain/proc/to_ipc_posi(mob/user)
+	var/obj/item/organ/internal/brain/synth/brain = new /obj/item/organ/internal/brain/synth
+	brainmob.container = null //Reset brainmob mmi var.
+	brainmob.forceMove(brain) //Throw mob into brain.
+	brainmob.set_stat(DEAD)
+	brainmob.emp_damage = 0
+	brainmob.reset_perspective() //so the brainmob follows the brain organ instead of the mmi. And to update our vision
+	brain.brainmob = brainmob //Set the brain to use the brainmob
+	brainmob = null //Set mmi brainmob var to null
+	src.forceMove(drop_location())
+	if(Adjacent(user))
+		user.put_in_hands(brain)
+	brain.organ_flags &= ~ORGAN_FROZEN
+	brain = null //No more brain in here
+	qdel(src)
 
 /obj/item/mmi/posibrain/proc/check_success()
 	searching = FALSE

--- a/monkestation/code/modules/mob/living/carbon/human/human.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/human.dm
@@ -12,3 +12,26 @@
 
 /mob/living/carbon/human/species/moth/tundra
 	race = /datum/species/moth/tundra
+
+/mob/living/carbon/human/species/ipc_empty
+	parent_type = /mob/living/carbon/human/species/ipc
+	// Override New() to remove organs and limbs
+	New()
+		..()
+		// Remove all organs
+		for (var/obj/item/organ/internal/O in organs_slot)
+			qdel(O)
+
+		for (var/obj/item/organ/internal/M in organs)
+			qdel(M)
+		// Remove all limbs
+		for (var/obj/item/bodypart/L in bodyparts)
+			if (L.body_part == CHEST)
+				continue
+			qdel(L)
+		// hair_style = "Bald"
+		// facial_hair_style = "Shaved"
+		// update_hair()
+		update_body()
+		set_stat(DEAD)
+		timeofdeath = world.time + 100000000000000000000

--- a/monkestation/code/modules/mob/living/carbon/human/human.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/human.dm
@@ -29,9 +29,9 @@
 			if (L.body_part == CHEST)
 				continue
 			qdel(L)
-		// hair_style = "Bald"
-		// facial_hair_style = "Shaved"
-		// update_hair()
+		underwear = "Nude"
+		facial_hairstyle = "Shaved"
+		hairstyle = "Bald"
 		update_body()
 		set_stat(DEAD)
 		timeofdeath = world.time + 100000000000000000000

--- a/monkestation/code/modules/research/designs/mechfabricator_designs.dm
+++ b/monkestation/code/modules/research/designs/mechfabricator_designs.dm
@@ -23,6 +23,19 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
+/datum/design/ipc_body
+	name = "IPC Body"
+	desc = "An IPC body made of metal. Now you can create your own IPC. Must be completed with other IPC parts."
+	id = "ipc_body"
+	build_type = MECHFAB
+	construction_time = 15 SECONDS
+	materials = list(/datum/material/iron = 20000, /datum/material/glass = 1000, /datum/material/silver = 200, /datum/material/gold = 400)
+	build_path = /mob/living/carbon/human/species/ipc_empty
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
+		)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
 /datum/design/ipc_part_chest
 	name = "IPC Replacement Chest"
 	id = "ipc_chest"

--- a/monkestation/code/modules/research/techweb/all_nodes.dm
+++ b/monkestation/code/modules/research/techweb/all_nodes.dm
@@ -216,6 +216,7 @@
 	prereq_ids = list("robotics")
 	design_ids = list(
 		"ipc_head",
+		"ipc_body",
 		"ipc_chest",
 		"ipc_arm_left",
 		"ipc_arm_right",


### PR DESCRIPTION
## About The Pull Request
This PR allows IPCs to be fully constructed in the mech fabricator. 

## Why It's Good For The Game
This adds a new way to obtain IPCs, making them more accessible and giving players more options for gameplay, and more uses for Posibrains.

# Changelog
* IPC bodies can be built in the mech fabricator.
* Posibrains can be transformed into IPC brains for use in IPC bodies.