### PR TITLE
"Ent" acceptance club

### DIFF
--- a/teatroespacial13/modules/mob/living/living_say.dm
+++ b/teatroespacial13/modules/mob/living/living_say.dm
@@ -9,7 +9,6 @@
     message = replacetext(message, regex(@"\bvsf\b", "gi"), "vai se fuder")
     message = replacetext(message, regex(@"\btnc\b", "gi"), "tomar no cu")
     message = replacetext(message, regex(@"\bsfd\b", "gi"), "se fuder")
-    message = replacetext(message, regex(@"\bent\b", "gi"), "então")
     message = replacetext(message, regex(@"\bwtf\b", "gi"), "mas que porra")
     message = replacetext(message, regex(@"\bmds\b", "gi"), "meu Deus")
     message = replacetext(message, regex(@"\bdnd\b", "gi"), "de nada")


### PR DESCRIPTION

## About The Pull Request
Quick edit to remove the  filter to "ent" as the current code can't detect "ã" as part of a word, so whenever someone said "então" the code would replace it with "entãoão"
## Why It's Good For The Game
Stops people from looking silly constantly saying "entãoão"
## Changelog
:cl:
del: Removed "ent" from the list of filters
/:cl:
