### PR TITLE
non-playable characters skin_tone fix

### DIFF
--- a/code/modules/client/preferences/skin_tone.dm
+++ b/code/modules/client/preferences/skin_tone.dm
@@ -39,6 +39,7 @@
 	return skintone2hex(random_skin_tone())
 
 /datum/preference/color/mix_skin_tone/apply_to_human(mob/living/carbon/human/target, value)
+	target.skin_tone = ""
 	if (value in GLOB.skin_tones_colors)
 		for (var/obj/item/bodypart/L in target.bodyparts)
 			L.icon_greyscale = 'monkestation/icons/mob/species/synth/bodypartsold.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -31,6 +31,8 @@
 
 /datum/species/human/on_species_gain(mob/living/carbon/human/target)
 	. = ..()
+	if (target.skin_tone != "")
+		target.dna.color_palettes[/datum/color_palette/generic_colors].mix_skin_tone = skintone2hex(target.skin_tone)
 	if (target.dna.color_palettes[/datum/color_palette/generic_colors].mix_skin_tone in GLOB.skin_tones_colors)
 		for (var/obj/item/bodypart/L in target.bodyparts)
 			L.icon_greyscale = 'monkestation/icons/mob/species/synth/bodypartsold.dmi'

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/synth.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/synth.dm
@@ -84,6 +84,8 @@
 	. = ..()
 	if (ishuman(C))
 		var/mob/living/carbon/human/target = C
+		if (target.skin_tone != "")
+			target.dna.color_palettes[/datum/color_palette/generic_colors].mix_skin_tone = skintone2hex(target.skin_tone)
 		if (target.dna.color_palettes[/datum/color_palette/generic_colors].mix_skin_tone in GLOB.skin_tones_colors)
 			for (var/obj/item/bodypart/L in target.bodyparts)
 				L.icon_greyscale = 'monkestation/icons/mob/species/synth/bodypartsold.dmi'


### PR DESCRIPTION
## About The Pull Request
Fixes non-playable characters from different sources not having skin tones. Like humanized monkeys and morgue bodies

## Why It's Good For The Game
Restores skin tones to non-playable characters and generated humans, improving visual consistency.

## Changelog
* non-playable characters and generated humans now have proper skin tones again.

