### PR TITLE
Interdyne and DS2 can`t be antag any more

### DIFF
--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -331,6 +331,12 @@ SUBSYSTEM_DEF(gamemode)
 
 		if(job_ban && is_banned_from(candidate.ckey, list(job_ban, ROLE_SYNDICATE)))
 			continue
+		var/isinterds2 = FALSE
+		for(var/faction as anything in candidate.faction)
+			if(ROLE_INTERDYNE_PLANETARY_BASE == faction || ROLE_INTERDYNE_PLANETARY_BASE_ICEBOX == faction || ROLE_DS2 == faction)
+				isinterds2 = TRUE
+		if(isinterds2)
+			continue
 		if(!candidate.client.prefs.read_preference(/datum/preference/toggle/beantagpref))
 			continue
 		candidates += candidate


### PR DESCRIPTION
## About The Pull Request
There was a bug where Interdyne and DS2 could be antagonists if they were inside the station. This has been fixed by removing them from the list of antag candidates.

## Why It's Good For The Game
They are ghost role they should not be antags.

## Changelog
* Interdyne removed from the antag candidates list.
* DS2 removed from the antag candidates list.