### PR TITLE
Pun Pun doesn't start nonsense fights more

### DIFF
--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -330,6 +330,8 @@
 				continue
 			if(HAS_AI_CONTROLLER_TYPE(possible_enemy, /datum/ai_controller/monkey) && !controller.blackboard[BB_MONKEY_TARGET_MONKEYS]) //Do not target poor monkes
 				continue
+			if(HAS_AI_CONTROLLER_TYPE(controller.pawn, /datum/ai_controller/monkey/pun_pun)) //Be a good Pun Pun
+				continue
 		// Weighted list, so the closer they are the more likely they are to be chosen as the enemy
 		valids[possible_enemy] = CEILING(100 / (get_dist(controller.pawn, possible_enemy) || 1), 1)
 


### PR DESCRIPTION
## About The Pull Request
Pun Pun will no longer start fights for no reason or become aggressive toward players without provocation.

## Why It's Good For The Game
This helps keep Pun Pun, our mascot alive. If he starts fights for no reason, he will likely be killed.

## Changelog
:cl:
balance: Pun Pun no longer starts fights without reason.
/:cl: